### PR TITLE
Fix some bugs

### DIFF
--- a/android-logcat.json
+++ b/android-logcat.json
@@ -8,11 +8,12 @@
     ],
     "regex": {
       "std-logcat-time": {
-        "pattern": "^(?<timestamp>\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?<lc_status>.{1})/(?<tag>\\S+\\s*)\\((?<pid>\\s?\\d+)\\):(?<body>.*)"
+        "pattern": "^(?<timestamp>\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) (?<lc_status>.{1})\/(?<tag>.*)\\((?<pid>\\s*\\d+)\\): (?<body>.*)$"
       }
     },
     "level-field": "lc_status",
     "level": {
+      "fatal": "F",
       "error": "E",
       "warning": "W",
       "info": "I",
@@ -22,7 +23,7 @@
     "value": {
       "lc_status": {
         "kind": "string",
-        "foreign-key": true
+        "identifier": true
       }, 
       "tag" : {"kind":"string", "identifier": true},
       "pid" : {"kind":"integer", "identifier":true},


### PR DESCRIPTION
1. Fix regex pattern:
    * It would be better to escape `/` symbol in some situations, where it is used as a delimiter.
    * Tags may have leading whitespace characters.
    * There will be more than one whitespace character before pid number, where pid number < 1000.
    * Add `$` symbol to asserts position at the end of a line.

2. Add `fatal` level
3. Change `foreign-key` to `identifier` in lc_status
  According to [formats doc](http://lnav.readthedocs.io/en/latest/formats.html), `foreign-key` should only need to be set for integer fields.
  > **foreign-key:**  A boolean that indicates that this field is a key and should not be graphed. This should only need to be set for integer fields.


